### PR TITLE
#2 Lookup Matching on Body

### DIFF
--- a/DoubleAgent/Sources/App/Models/CallInfo.swift
+++ b/DoubleAgent/Sources/App/Models/CallInfo.swift
@@ -79,15 +79,16 @@ public struct CallLookup: Content
     var path: [String: String]?
     var query: [String: String]?
     var headers: HTTPHeaders?
-    // let body ????
+    var body: String?
 
-    var count: Int { (query?.count ?? 0) + (headers?.count ?? 0) }
+    var weight: Int { (query?.count ?? 0) + (headers?.count ?? 0) + (body == nil ? 0 : 9999) }
 
-    init(path: [String: String]?, query: [String: String]?, headers: HTTPHeaders?)
+    init(path: [String: String]?, query: [String: String]?, headers: HTTPHeaders?, body: String?)
     {
         self.path = path
         self.query = query
         self.headers = headers
+        self.body = body
     }
 }
 

--- a/DoubleAgent/Tests/AppTests/MocksServerTestCase.swift
+++ b/DoubleAgent/Tests/AppTests/MocksServerTestCase.swift
@@ -12,6 +12,7 @@ class MocksServerTestCase: XCTestCase
 {
     var app: Application!
     var contentTypeJSON: HTTPHeaders { ["Content-Type": "application/json"] }
+    var contentTypeTextPlain: HTTPHeaders { ["Content-Type": "text/plain"] }
 
     override func setUpWithError() throws
     {

--- a/DoubleAgent/Tests/AppTests/Models/MockCallInfo.swift
+++ b/DoubleAgent/Tests/AppTests/Models/MockCallInfo.swift
@@ -48,10 +48,11 @@ extension CallLookup
     static func stub(
         path: [String: String]? = nil,
         query: [String: String]? = nil,
-        headers: HTTPHeaders? = nil
+        headers: HTTPHeaders? = nil,
+        body: String? = nil
     ) -> CallLookup
     {
-        return CallLookup(path: path, query: query, headers: headers)
+        return CallLookup(path: path, query: query, headers: headers, body: body)
     }
 }
 

--- a/DoubleAgent/spec-example.json
+++ b/DoubleAgent/spec-example.json
@@ -11,7 +11,8 @@
     },
     "query": {
       "queryKey": "valueAsString_MUST_be_present_to_match",
-    }
+    },
+    "body": "{\"key\":\"Some escaped JSON in a String or a plain String\"}"
   },
   "response": {
     "status": 201,

--- a/DoubleAgent/spec.swagger
+++ b/DoubleAgent/spec.swagger
@@ -96,6 +96,10 @@ definitions:
           "queryKey": "valueAsString MUST be present to match",
           "rule": "query items not present in the query dictionary are ignored"
         }
+      body:
+        type: "string"
+        description: "A plain string or the string representation of JSON. If the string can be interpreted as valid JSON It will and equality will be based on JSON not on the exact String\nThe whole budy must match, there is NO partial matching."
+        example: "{\"key\":\"Some escaped JSON in a String or a plain String\"}"
   Response:
     type: "object"
     description: "Define the HTTP response to return on a positive match."


### PR DESCRIPTION
Add Lookup Body #2 .

* The body must be provided as a String
* The String can be a JSON representation
* If String is a valid JSON representation, NSArray and NSDictionary equality will be used for matching
* If String is not a valid JSON representation exact String equality will be used
* Body lookup out weight "query" and "header" lookup