### PR TITLE
#18 Resolve macOS Alias for .json files in the input directory

### DIFF
--- a/Tools/toDoubleAgent/Sources/toDoubleAgent/main.swift
+++ b/Tools/toDoubleAgent/Sources/toDoubleAgent/main.swift
@@ -115,7 +115,10 @@ func jsonURLsAt(_ url: URL) throws -> [URL]
         includingPropertiesForKeys: nil,
         options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
     )
-    let jsonURLs = folderContent.filter { $0.pathExtension.lowercased() == "json" }
+    let jsonURLs =
+        try folderContent
+            .filter { $0.pathExtension.lowercased() == "json" }
+            .map { try URL(resolvingAliasFileAt: $0) }
     return jsonURLs
 }
 


### PR DESCRIPTION
The Alias must have the .json extension to be resolved